### PR TITLE
REMOVE: ?rel=0 from YouTube iframe URLs so that users can more easily…

### DIFF
--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -31,7 +31,7 @@
 						class="theme-video embed-responsive embed-responsive-16by9">
 						<iframe loading="lazy" class="lazyload embed-responsive-item"
 							{% include allow-fullscreen.html %}
-							data-src="{{ session.video }}?rel=0"></iframe>
+							data-src="{{ session.video }}"></iframe>
 					</div>
 					{% endif %}
 					<p class="theme-description">{{ session.description }}</p>


### PR DESCRIPTION
… pop out the video into a new window or tab

Closes #7 