### PR TITLE
add web team to "Team" page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -310,6 +310,7 @@ teamBlockTitle: "About us"
 aboutUs: "The Academic Library Association of Ohio (ALAO) is a chapter of the Association of College and Research Libraries (ACRL). ALAO exists to develop, promote, and improve library and information services in Ohio’s higher education community, to advance the interests of academic librarianship and the personnel of academic libraries, and to provide leadership and advocacy for the educational and policy concerns of the academic library community in Ohio."
 showOrganizers: True
 showProgramCommittee: False
+showWebTeam: true
 
 # -------------------------------------------------------------
 # Tickets Block

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -5,7 +5,7 @@
   title: 'Lead - Conference Website'
   thumbnailUrl: derek_zoladz.jpg
   organizer: true
-  programCommittee: false
+  webTeam: false
   ribbon:
     - { abbr: 'OhioNET', title: 'Library Systems Analyst' }
   social:
@@ -20,7 +20,7 @@
   title: 'Performing Arts & Humanities Librarian; OER & Copyright Advisor (Chair)'
   thumbnailUrl: mandi_goodsett.jpg
   organizer: true
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Cleveland State University',
@@ -34,7 +34,7 @@
   title: 'Library Specialist'
   thumbnailUrl: don_appleby.jpg
   organizer: true
-  programCommittee: false
+  webTeam: false
   ribbon:
     - { abbr: 'University of Akron', title: 'library Specialist' }
 
@@ -45,7 +45,7 @@
   title: 'Coordinator of Access Services'
   thumbnailUrl: amanda_black.jpg
   organizer: true
-  programCommittee: false
+  webTeam: false
   ribbon:
     - { abbr: 'University of Dayton', title: 'Coordinator of Access Services' }
 
@@ -56,7 +56,7 @@
   title: 'Electronic Resources Librarian'
   thumbnailUrl: heather_crozier.jpg
   organizer: true
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Ohio Northern University',
@@ -72,7 +72,7 @@
   title: 'Librarian, Research Services'
   thumbnailUrl: mark_eddy.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Case Western Reserve University',
@@ -85,8 +85,8 @@
   pronouns: 'she/her/hers'
   title: 'Serials & Electronic Resources Manager'
   thumbnailUrl: melissa_hill.jpg
-  organizer: True
-  programCommittee: false
+  organizer: true
+  webTeam: true
   ribbon:
     - {
         abbr: 'Ohio Wesleyan University',
@@ -99,8 +99,8 @@
   pronouns: 'he/him/his'
   title: 'Web Services Librarian'
   thumbnailUrl: ken_irwin.jpg
-  organizer: True
-  programCommittee: false
+  organizer: true
+  webTeam: true
   ribbon:
     - { abbr: 'Miami University', title: 'Web Services Librarian' }
   social:
@@ -115,7 +115,7 @@
   title: 'Assistant Director of Library Services; ALAO Instruction Group Cooardinator'
   thumbnailUrl: sara_klink.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Stark State College',
@@ -129,7 +129,7 @@
   title: 'Reference & Instruction Librarian'
   thumbnailUrl: stacey_mckenna.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'The Ohio State University at Newark/ Central Ohio Technical College',
@@ -143,7 +143,7 @@
   title: 'Head, Collections and Digital Initiatives'
   thumbnailUrl: marsha_miles.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Cleveland State University',
@@ -159,7 +159,7 @@
   title: 'Director of Library Communications'
   thumbnailUrl: melissa_cox_norris.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'University of Cincinnati',
@@ -173,7 +173,7 @@
   title: 'Electronic Access Librarian'
   thumbnailUrl: allen_reichert.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - { abbr: 'Otterbein University', title: 'Electronic Access Librarian' }
 
@@ -183,8 +183,8 @@
   pronouns: 'he/him/his'
   title: 'Reference Librarian'
   thumbnailUrl: ryan_scott.jpg
-  organizer: True
-  programCommittee: false
+  organizer: true
+  webTeam: true
   ribbon:
     - { abbr: 'Columbus State Community College', title: 'Reference Librarian' }
 
@@ -195,7 +195,7 @@
   title: 'Electronic Resources Librarian'
   thumbnailUrl: shelby_stuart.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'Case Western Reserve University',
@@ -209,7 +209,7 @@
   title: 'Reference & Instruction Librarian'
   thumbnailUrl: zach_walton.jpg
   organizer: True
-  programCommittee: false
+  webTeam: false
   ribbon:
     - {
         abbr: 'The Ohio State University at Lima',

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -9,7 +9,7 @@
         {% if site.showOrganizers == true %}
         <div class="col-lg-10 col-lg-offset-1 text-center">
             <h3 class=" h4text-left animated hiding appear-animation-trigger"
-                data-animation="fadeInUp" data-delay="0">Organizers</h3>
+                data-animation="fadeInUp" data-delay="0">Conference Planning Committee</h3>
             {% assign team = site.data.team | sort: "surname" %}
             {% for teamMember in team %} {% if teamMember.organizer == true %}
             <div
@@ -52,12 +52,12 @@
             {% endif %} {% endfor %}
         </div>
         {% endif %}
-        {% if site.showProgramCommittee == true %}
+        {% if site.showWebTeam == true %}
         <div class="col-lg-10 col-lg-offset-1 text-center">
             <h4 class="text-left animated hiding appear-animation-trigger"
-                data-animation="fadeInUp" data-delay="0">Program committee</h4>
+                data-animation="fadeInUp" data-delay="0">Conference Website Team</h4>
             {% for teamMember in site.data.team %}
-            {% if teamMember.programCommittee == true %}
+            {% if teamMember.webTeam == true %}
             <div
                 class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">
                 <div class="zoe-effect" data-toggle="modal"


### PR DESCRIPTION
* adds the web team to the `/team` page
* does the structural part of #26
* _data/team.yml needs to be updated to include current CPC and Web Team members

Data we'll need from members includes:
* name
* pronouns
* job title
* institution
* headshot
* social media links (optional) (e.g. twitter, github, etc)