### PR TITLE
added OLSSI sponsor on session 209

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -196,6 +196,15 @@
   audience: AIG, Library administration/supervision, diversity, consortia, emerging technologies, reference
   keywords: Change Management, Change Readiness, Team work, Human-Centered, Leadership, Facilitation
   note-presenter-names: Annie Bélanger,Meghan Musolff,
+  sponsor:
+    group: Individual Session Sponsor
+    elements:
+      - {
+          name: 'Ohio Library Support Staff Institute (OLSSI)',
+          description: '',
+          link: 'https://olssi.org/',
+          imageUrl: 'olssi.png',
+        }
 
 - id: 210
   subtype: lightning

--- a/_includes/sponsors-per-session.html
+++ b/_includes/sponsors-per-session.html
@@ -11,6 +11,7 @@
   }
 </style>
 
+<!-- Gold and Sessions Sponsors -->
 <div class="row">
   {% for sponsor in site.data.sponsors %}
   {% if sponsor.group == 'Gold' or sponsor.group == include.sessionType %}
@@ -40,6 +41,38 @@
   </div>
   {% endif %}
   {% endfor %}
+
+<!-- Individual Session Sponsors -->
+  {% if session.sponsor %}
+  {% assign sponsor = session.sponsor %}
+  <div class="sponsorGroupWrapper">
+    <div class="h3">{{ sponsor.group }}</div>
+    <ul class="list-inline">
+      {% for element in sponsor.elements %}
+      <li>
+        <a href="{{ element.link }}" target="_blank">
+          <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
+            loading="lazy"
+               title="{{ element.description }}" alt="{{ element.name }}"
+            style="width:100%" />
+        </a>
+        {% if element.video %}
+        <div class="sponsors video-container">
+          <div class="sponsors video-modals">
+            <a href="{{ element.video }}"
+              aria-label='Sponsor video for {{ element.name }}'>
+              <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
+            </a>
+          </div>
+        </div>
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+<!-- Additional Support -->
 
   {% if session.additional_support or include.additional_support != nil %}
   {% for sponsor in site.data.sponsors %}

--- a/_includes/sponsors-per-session.html
+++ b/_includes/sponsors-per-session.html
@@ -10,6 +10,35 @@
     padding-bottom: 5px;
   }
 </style>
+<!-- Individual Session Sponsors -->
+{% if session.sponsor %}
+{% assign sponsor = session.sponsor %}
+<div class="sponsorGroupWrapper">
+  <div class="h3">{{ sponsor.group }}</div>
+  <ul class="list-inline">
+    {% for element in sponsor.elements %}
+    <li>
+      <a href="{{ element.link }}" target="_blank">
+        <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
+          loading="lazy"
+             title="{{ element.description }}" alt="{{ element.name }}"
+          style="width:100%" />
+      </a>
+      {% if element.video %}
+      <div class="sponsors video-container">
+        <div class="sponsors video-modals">
+          <a href="{{ element.video }}"
+            aria-label='Sponsor video for {{ element.name }}'>
+            <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
+          </a>
+        </div>
+      </div>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
 
 <!-- Gold and Sessions Sponsors -->
 <div class="row">
@@ -41,36 +70,6 @@
   </div>
   {% endif %}
   {% endfor %}
-
-<!-- Individual Session Sponsors -->
-  {% if session.sponsor %}
-  {% assign sponsor = session.sponsor %}
-  <div class="sponsorGroupWrapper">
-    <div class="h3">{{ sponsor.group }}</div>
-    <ul class="list-inline">
-      {% for element in sponsor.elements %}
-      <li>
-        <a href="{{ element.link }}" target="_blank">
-          <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
-            loading="lazy"
-               title="{{ element.description }}" alt="{{ element.name }}"
-            style="width:100%" />
-        </a>
-        {% if element.video %}
-        <div class="sponsors video-container">
-          <div class="sponsors video-modals">
-            <a href="{{ element.video }}"
-              aria-label='Sponsor video for {{ element.name }}'>
-              <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
-            </a>
-          </div>
-        </div>
-      </li>
-      {% endif %}
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
 
 <!-- Additional Support -->
 


### PR DESCRIPTION
* closes #60 
* creates mechanism for displaying session-level sponsors
* to test:
  * https://deploy-preview-86--keen-feynman-3ae551.netlify.app/schedule/#session-209
  * session details for: "Practicing organizational care: Using human-centered approaches to facilitate change in your library"
  * At the bottom of the page modal, you should see the Individual Session Sponsor: OLSSI, plus the the regular sponsors (Gold & Sessions)