### PR TITLE
CHANGE: bump offset so 3 featured speakers are centered

### DIFF
--- a/_includes/speaker-div.html
+++ b/_includes/speaker-div.html
@@ -1,5 +1,5 @@
 {% if speaker.rockstar == true %}
-<div class="effect-wrapper col-sm-6 col-xs-12 appear-animation rockstar">
+<div class="effect-wrapper col-lg-4 col-sm-6 col-xs-12 appear-animation rockstar">
     {% else %}
     <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 appear-animation">
         {% endif %}
@@ -40,3 +40,4 @@
             </figure>
         </div>
     </div>
+

--- a/_includes/speakers-list-2.html
+++ b/_includes/speakers-list-2.html
@@ -3,7 +3,7 @@
     <div class="content-wrapper">
         <h2>Featured Speakers</h2>
         <div class="row">
-            <div class="col-lg-10 col-lg-offset-2 appear-animation-trigger">
+            <div class="col-lg-8 col-lg-offset-2 appear-animation-trigger">
                 {% assign sorted_speakers = (site.data.speakers | where: "rockstar", "true" | sort: "surname") %}
                 {% for speaker in sorted_speakers %}
                 {% include speaker-div.html %}

--- a/_includes/speakers-list-2.html
+++ b/_includes/speakers-list-2.html
@@ -3,7 +3,7 @@
     <div class="content-wrapper">
         <h2>Featured Speakers</h2>
         <div class="row">
-            <div class="col-lg-10 col-lg-offset-1 appear-animation-trigger">
+            <div class="col-lg-10 col-lg-offset-2 appear-animation-trigger">
                 {% assign sorted_speakers = (site.data.speakers | where: "rockstar", "true" | sort: "surname") %}
                 {% for speaker in sorted_speakers %}
                 {% include speaker-div.html %}


### PR DESCRIPTION
This is an optional pull request. It adjusts the placement of the three featured speakers so that they are centered on the page. They should continue to stack on a mobile view as well. To test this:

- pull the branch
- jekyll serve
- navigate to the Speakers page

The featured speakers should be centered on the page rather than left aligned. Constrain the viewport to ensure that the three speakers stack vertically still.