### PR TITLE
fix missing iframe title

### DIFF
--- a/_includes/poster.html
+++ b/_includes/poster.html
@@ -45,7 +45,7 @@
                   <h4 class="h5">{{doc.title}}</h4>
                   <div
                     class="theme-video embed-responsive embed-responsive-16by9">
-                    <iframe class="embed-responsive-item"
+                    <iframe title="{{doc.title}}" class="embed-responsive-item"
                       {% include allow-fullscreen.html %}
                       src="{{ doc.url }}?rel=0"></iframe>
                   </div>


### PR DESCRIPTION
closes #103

To test, add these lines below the `session-contents:` of a _post and reload the page. You should find that the title gets added to the title attribute of the iframe:
```
  - type: video
    url: //www.youtube.com/embed/Zp1I0vMLr7U
    title: Intro Video
```