### PR TITLE
add some show/hide variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -273,7 +273,7 @@ serviceprojectLocations:
 
 
 # -------------------------------------------------------------
-# Speakers List Block
+# Sessions
 # -------------------------------------------------------------
 showSessions: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ title: "ALAO Virtual Conference 2020"
 email: "2021-cpc@alaoweb.org"
 description: "Virtual Conference"
 permalink: "/posters/:title"
+
 #############################################################################
 
 
@@ -202,6 +203,7 @@ sponsorsTitle: "Conference Sponsors"
 postersTitle: "POSTER SESSIONS"
 postersBackground: 2021alao-header-image.svg
 showPosters: true
+showPosterContent: false
 noPostersText: "Posters Forthcoming"
 postersCommentsEnabled: true
 discusShortName: "alaoweb"
@@ -298,11 +300,12 @@ subscribeInfo: "Stay Informed of ALAO Events!"
 # -------------------------------------------------------------
 # Surveys
 # -------------------------------------------------------------
-sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdVgEk_d_Ed4mt7lBNZQx2XzT9fP1C7a5KFME1vyToYB8NDFA/viewform?usp=pp_url"
-sessionFeedbackParameter: "entry.1153076421"
-preconferenceWorkshopFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScr9oiR9VEgU77lISo2YV_MkrC3SK-D_7ixZ14UYr9L4AWz0w/viewform"
-preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScrp2h3Of9-7skigJ3H8-r9R51we8bVZOCj2D1eMY6hhGFh_Q/viewform"
-keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdAuGKiH8bP95KnrvQQarT8_hEOFp_XO3YHFHwlVwDwFuTFAQ/viewform"
+# currently showing 2020 survey links
+# sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdVgEk_d_Ed4mt7lBNZQx2XzT9fP1C7a5KFME1vyToYB8NDFA/viewform?usp=pp_url"
+# sessionFeedbackParameter: "entry.1153076421"
+# preconferenceWorkshopFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScr9oiR9VEgU77lISo2YV_MkrC3SK-D_7ixZ14UYr9L4AWz0w/viewform"
+# preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScrp2h3Of9-7skigJ3H8-r9R51we8bVZOCj2D1eMY6hhGFh_Q/viewform"
+# keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdAuGKiH8bP95KnrvQQarT8_hEOFp_XO3YHFHwlVwDwFuTFAQ/viewform"
 
 # -------------------------------------------------------------
 # Team Block

--- a/_includes/poster.html
+++ b/_includes/poster.html
@@ -36,7 +36,7 @@
               <p>{{ page.description }}</p>
             </div>
             <div class="poster-content">
-              {% if page.session-contents %}
+              {% if page.session-contents and site.showPosterContent %}
               <h3>Poster</h3>
               {% for doc in page.session-contents %}
               <div class="poster-document">

--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -35,7 +35,7 @@
 					</div>
 					{% endif %}
 					<p class="theme-description">{{ session.description }}</p>
-					{% if session.subtype == 'session' %}
+					{% if session.subtype == 'session' and site.sessionFeedbackForm != null %}
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">
@@ -46,7 +46,7 @@
 								Feedback</a>
 						</div>
 					</div>
-					{% elsif session.subtype == 'keynote' %}
+					{% elsif session.subtype == 'keynote' and site.keynoteFeedbackForm != null  %}
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">
@@ -57,7 +57,7 @@
 								Feedback</a>
 						</div>
 					</div>
-					{% elsif session.subtype == 'preconference' %}
+					{% elsif session.subtype == 'preconference' and site.preconferenceFeedbackForm %}
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">
@@ -68,7 +68,7 @@
 								Feedback</a>
 						</div>
 					</div>
-					{% elsif session.subtype == 'workshop' %}
+					{% elsif session.subtype == 'workshop' and site.preconferenceWorkshopFeedbackForm %}
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">


### PR DESCRIPTION
* closes #13 

The original intent of this issue was to create conference modes to change setting (e.g. what content gets shown before, during, and after the conference). But some of those kinds of variables already existed not as time-based "modes" but as boolean do-or-do-not-show. So I went further down that path and added variables to show/hide:
* poster content (the videos, etc they'll be submitting later, as opposed to the abstract, etc. that's already available)
* hides survey links until they have urls assigned

###To test:
To test posters with and with out content, add this to the session-contents of one of the posters:
```
 - type: video
    url: //www.youtube.com/embed/0FHiJ8Fajj0
    title: Intro Video
```
and then change _config.yml to showPosterContents: `true` or `false` 
the page should render with a video showing when true; not when false.

To test the survey links - currently when you view session info (e.g. by clicking a link in the schedule) you'll see a link to the feedback form. In this PR, that should be turned off for now by commenting out the "Surveys" section in _config.yml. If you reactivate that section, you should see the links again.

Remember: when working with changes to _config.yml, you'll have to re-do the 
```
bundle exec jekyll build
bundle exec jekyll serve
```
sequence