### PR TITLE
Add survey links for 2021 conference 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -301,10 +301,12 @@ subscribeInfo: "Stay Informed of ALAO Events!"
 # Surveys
 # -------------------------------------------------------------
 # currently showing 2021 survey links
-sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdLzPAjyAt3hZQinnf8NWP_7qYGk-ZbCGVyCRKURczte6djvQ/viewform?usp=pp_url"
-sessionFeedbackParameter: "entry.1153076421"
-keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSedR9Cm9jG7RQ9AxN7v2km_BxgdwCyl_HTVpVCnk86jSvJIug/viewform?usp=pp_url&entry.1153076421="
-preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdzxxqW748MuWXLjc-MYaBZHABpZAzA_XBZ5X5IRhgNnUUq_g/viewform"
+# deactivate until conference time
+# sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdLzPAjyAt3hZQinnf8NWP_7qYGk-ZbCGVyCRKURczte6djvQ/viewform?usp=pp_url"
+# sessionFeedbackParameter: "entry.1153076421"
+# keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSedR9Cm9jG7RQ9AxN7v2km_BxgdwCyl_HTVpVCnk86jSvJIug/viewform?usp=pp_url&entry.1153076421="
+# preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdzxxqW748MuWXLjc-MYaBZHABpZAzA_XBZ5X5IRhgNnUUq_g/viewform"
+
 # leftover from 2020 as not needed in 2021:
 # preconferenceWorkshopFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScr9oiR9VEgU77lISo2YV_MkrC3SK-D_7ixZ14UYr9L4AWz0w/viewform"
 

--- a/_config.yml
+++ b/_config.yml
@@ -300,12 +300,14 @@ subscribeInfo: "Stay Informed of ALAO Events!"
 # -------------------------------------------------------------
 # Surveys
 # -------------------------------------------------------------
-# currently showing 2020 survey links
-# sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdVgEk_d_Ed4mt7lBNZQx2XzT9fP1C7a5KFME1vyToYB8NDFA/viewform?usp=pp_url"
-# sessionFeedbackParameter: "entry.1153076421"
+# currently showing 2021 survey links
+sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdLzPAjyAt3hZQinnf8NWP_7qYGk-ZbCGVyCRKURczte6djvQ/viewform?usp=pp_url"
+sessionFeedbackParameter: "entry.1153076421"
+keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSedR9Cm9jG7RQ9AxN7v2km_BxgdwCyl_HTVpVCnk86jSvJIug/viewform?usp=pp_url&entry.1153076421="
+preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdzxxqW748MuWXLjc-MYaBZHABpZAzA_XBZ5X5IRhgNnUUq_g/viewform"
+# leftover from 2020 as not needed in 2021:
 # preconferenceWorkshopFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScr9oiR9VEgU77lISo2YV_MkrC3SK-D_7ixZ14UYr9L4AWz0w/viewform"
-# preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLScrp2h3Of9-7skigJ3H8-r9R51we8bVZOCj2D1eMY6hhGFh_Q/viewform"
-# keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdAuGKiH8bP95KnrvQQarT8_hEOFp_XO3YHFHwlVwDwFuTFAQ/viewform"
+
 
 # -------------------------------------------------------------
 # Team Block

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -91,13 +91,13 @@
 - id: 102
   title: 'Preconference: Loving thy Neighbor: Creating Coalitions and Deconstructing Vocational Awe'
   description: "Librarianship is a service profession. It is considered one of the Core Values of Librarianship as well as being in the American Library Association’s Code of Ethics (ALA 2016). The ability to “love thy neighbor as thyself” (King James Bible 1769/2019) therefore, is seen as one of the most, if not the most, important traits a librarian can have. According to Deborah Hicks, the professional identity of a librarian “transcends other non-professional identities, such as one’s gender or race identity...” (2016). Taken to its extreme, this means that the ideal librarian is one whose other identities are subsumed by the “noble calling” of library work to the exclusion, and even detriment, of anything else. This, along with the problematic rhetoric of “do what you love” (Tokumitsu 2015), enables the exploitation of librarians as workers by eliminating the distinction between personal and professional identities. When there is immense resistance to merely acknowledging flaws in our professional values and practice, how can we work towards meaningful change?<br><br>In this workshop, we will learn about vocational awe, how it impacts the work-life balance of library workers, and how to deconstruct it so that we can all truly learn how to love ourselves as much as our neighbor."
-  subtype: workshop
+  subtype: preconference
   speakers: [2]
   language:
   complexity:
   handouts:
   video:
-  live-stream-type: workshop
+  live-stream-type: preconference
   live-stream-time: '2021-10-27 15:30:00'
   live-stream-link:
 

--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -59,7 +59,7 @@
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">
-							<a href="{{ site.keynoteFeedbackForm }}"
+							<a href="{{ site.keynoteFeedbackForm }}{{session.title | url_encode }}"
 								class="survey-button btn"
 								target="_blank"
 								aria-label="Complete the survey for {{ session.title }}}">{{session.subtype | capitalize }}


### PR DESCRIPTION
Add survey links for 2021 conference 

These are actually turned off for now, as they should be before the conference starts. But I've updated the survey links in the config files to the current (2021) values. 

To test: 
* check out this branch
* uncomment the these lines from the "Surveys" section of _config.yml (ca. line 300): 
```
# sessionFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdLzPAjyAt3hZQinnf8NWP_7qYGk-ZbCGVyCRKURczte6djvQ/viewform?usp=pp_url"
# sessionFeedbackParameter: "entry.1153076421"
# keynoteFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSedR9Cm9jG7RQ9AxN7v2km_BxgdwCyl_HTVpVCnk86jSvJIug/viewform?usp=pp_url&entry.1153076421="
# preconferenceFeedbackForm: "https://docs.google.com/forms/d/e/1FAIpQLSdzxxqW748MuWXLjc-MYaBZHABpZAzA_XBZ5X5IRhgNnUUq_g/viewform"
```

Then do `bundle exec jekyll build` and `bundle exec jekyll serve`. On the schedule page, you should be able to click on a session, keynote, or preconference and there will be a feedback link that should take you to a survey page. For Keynotes and Sessions, the name of the session should be imported into the first field of the form. 