### PR TITLE
poster settings: suppress supplements & voting for now

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -204,12 +204,12 @@ sponsorsTitle: "Conference Sponsors"
 postersTitle: "POSTER SESSIONS"
 postersBackground: 2021alao-header-image.svg
 showPosters: true
-showPosterContent: false
+showPosterContent: false #true
 noPostersText: "Posters Forthcoming"
 postersCommentsEnabled: true
 discusShortName: "alaoweb"
-showPosterVoting: true
-posterVotingLink: "https://docs.google.com/forms/d/e/1FAIpQLSfas6Fj3iaA20Ma6GwHoRjKubYWRQS14ZQ6pL_58RSEmXcnUw/viewform"
+showPosterVoting: false
+posterVotingLink: "https://docs.google.com/forms/d/e/1FAIpQLSeSYObOdyLkVay5jtIA362TWCPdf-vkVTywNndd4Zzw0xA1Cg/viewform"
 
 # -------------------------------------------------------------
 # Preconference

--- a/_includes/poster.html
+++ b/_includes/poster.html
@@ -69,7 +69,7 @@
               </div>
               {% endfor %}
               {% endif %}
-              {% if page.supplemental-docs %}
+              {% if page.supplemental-docs and site.showPosterContent %}
               <div class="supplemental-docs">
                 <h4 class="h5">Supplemental Documents</h4>
                 <ul class="fa-ul">


### PR DESCRIPTION
* closes #175 
* adds 2021 links for poster voting, but also suppresses it for now
* suppresses poster supplemental documents until the posters are published