### PR TITLE
Better schedule sponsors

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -72,7 +72,7 @@
               </div>
             </div>
             {% elsif slot == session.id and session.service != null %}
-            <div 
+            <div
               class="slot col-md-{{ slotColWidth }} col-xs-12 service-slot flexbox-item-height"
               data-slot-detail="{{ session.place }}">
               <div class="color-line"></div>
@@ -92,7 +92,8 @@
         </div>
         {% endfor %}
       </div>
-      <div class="schedule-sponsors col-lg-3 col-md-3">
+      {% if forloop.first == true %}
+      <div class="schedule-sponsors col-lg-2 col-md-2">
         <div class="sponsorGroupWrapper">
           <div class="h3">Schedule Sponsors</h3>
         </div>
@@ -116,7 +117,8 @@
         {% endfor %}
       </div>
     </div>
-    
+      {% endif %}
+
     {% endfor %}
   </div>
 </section>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -92,7 +92,6 @@
         </div>
         {% endfor %}
       </div>
-      {% if forloop.first == true %}
       <div class="schedule-sponsors col-lg-2 col-md-2">
         <div class="sponsorGroupWrapper">
           <div class="h3">Schedule Sponsors</h3>
@@ -117,8 +116,7 @@
         {% endfor %}
       </div>
     </div>
-      {% endif %}
-
+    </div>
     {% endfor %}
   </div>
 </section>

--- a/_includes/sponsors-per-session.html
+++ b/_includes/sponsors-per-session.html
@@ -1,15 +1,3 @@
-<style>
-  .sponsorGroupWrapper li {
-    padding-right: 20%;
-    margin-bottom: 1rem;
-  }
-
-  .sponsorGroupWrapper .h3 {
-    border-bottom: 1px solid #757575 !important;
-    font-size: 30px;
-    padding-bottom: 5px;
-  }
-</style>
 <!-- Individual Session Sponsors -->
 {% if session.sponsor %}
 {% assign sponsor = session.sponsor %}
@@ -20,7 +8,7 @@
 
 {% if sponsor %}
 <div class="sponsorGroupWrapper">
-  <div class="h3">{{ sponsor.group }}</div>
+  <div class="sponsors h3">{{ sponsor.group }}</div>
   <ul class="list-inline">
     {% for element in sponsor.elements %}
     <li>
@@ -51,7 +39,7 @@
   {% for sponsor in site.data.sponsors %}
   {% if sponsor.group == 'Gold' or sponsor.group == include.sessionType %}
   <div class="sponsorGroupWrapper">
-    <div class="h3">{{ sponsor.group }} Sponsors</div>
+    <div class="sponsors h3">{{ sponsor.group }} Sponsors</div>
     <ul class="list-inline">
       {% for element in sponsor.elements %}
       <li>
@@ -83,7 +71,7 @@
   {% for sponsor in site.data.sponsors %}
   {% if sponsor.group == 'Additional Support' %}
   <div class="sponsorGroupWrapper">
-    <div class="h3">{{ sponsor.group }}</div>
+    <div class="sponsors h3">{{ sponsor.group }}</div>
     <ul class="list-inline">
       {% for element in sponsor.elements %}
       {% if element.name == session.additional_support or element.name == include.additional_support %}

--- a/_sass/partials/_schedule.scss
+++ b/_sass/partials/_schedule.scss
@@ -201,9 +201,6 @@ $small-label-width: 80px;
 }
 .schedule-sponsors {
   list-style: none;
-  li {
-    margin-bottom: 5em;
-  }
   img {
     width: 80%;
   }

--- a/_sass/partials/_sponsors.scss
+++ b/_sass/partials/_sponsors.scss
@@ -10,7 +10,6 @@
     margin-top: 10px;
   }
   .video {
-    display: table-cell;
     text-align: center;
     vertical-align: middle;
   }
@@ -20,6 +19,7 @@
     padding: 10px 0px 10px 0px;
   }
   .video-link {
+    margin-top: 2%;
     color: #ff0000;
     transition: all .2s ease-in-out;
     &:hover {
@@ -58,6 +58,7 @@
       }
     }
   }
+
   img {
     width: 100%;
     transition: $base-transition;
@@ -68,3 +69,14 @@
   }
 }
 
+.sponsorGroupWrapper .h3 {
+  border-bottom: 1px solid #757575 !important;
+  font-size: 30px;
+  padding-bottom: 5px;
+}
+
+.sponsorGroupWrapper li {
+  margin-bottom: 1rem;
+  padding: 5% 0;
+  border-bottom: 1px solid #eee;
+}


### PR DESCRIPTION
Partially addresses #15 

This PR adjusts some markup and CSS to better present the vendor slots next to the schedule and in a session details page.

To test, examine the vendor images on the right-hand column of the schedule. 

This also unintentionally fixes a layout issue with the schedule tables. On smaller screens, they do not line up properly and tend to go "off screen" the further down you go. Something must not have been nested properly in the past but it is fixed now.