### PR TITLE
Add Alt Text to Team Social Icons

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -39,7 +39,7 @@
                                 {% endif %}
                             {% for social in teamMember.social %}
                             <a href="{{ social["link"] }}" target="_blank">
-                                <svg class="icon icon-{{ social["name"] }}"
+                                <svg class="icon icon-{{ social.name }}" alt="{{ teamMember.name| capitalize }} {{ teamMember.surname | capitalize}}'s {{social.name| capitalize}}"
                                     viewBox="0 0 30 32">
                                     <use
                                         xlink:href="{{ site.baseurl }}/img/sprites/sprites.svg#icon-{{ social["name"] }}">


### PR DESCRIPTION
Similar fix to the social icons made for the Speakers page. Should hopefully add alt text for the social media icons on the Team page.