### PR TITLE
Reformat lightning, remove random Carissa Thatcher typo, swap a video for newer version

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -610,7 +610,7 @@
   audience: ['DLIG', 'IIG', 'SCAIG']
   keywords: Primary sources, instruction, archives, asynchronous, online learning, active-learning, faculty/librarian collaboration
   note-presenter-names: Paul C. Campbell ,Miriam Intrator ,
-  video: https://youtube.com/embed/JhDfnvrrB_s
+  video: https://youtube.com/embed/fupoKVy6xLI
   live-stream-type: session
   live-stream-time: '2021-10-29 14:30:00'
   live-stream-link: https://zoom.us/j/96662773969?pwd=eXY3cFl4K2kxMHQ5VkM1YjU3TTl6dz09


### PR DESCRIPTION
* closes #200 
* updates lightning talk descriptions to use bullet points for the different talk names and adds the authors in parens after each
* removes Carissa Thatcher's name from Lighting Talk #2, which was a typo to begin with
* also link to an updated version of Paul Campbell & Miriam Intrator's video ([session 311](http://localhost:4000/schedule/#session-311))