### PR TITLE
removed speaker with no session

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -439,18 +439,6 @@
   ribbon:
   social:
 
-- id: 36
-  name: Jillian
-  surname: Ewalt
-  pronouns: she/her
-  company: University of Dayton
-  email: jewalt1@udayton.edu
-  bio: Jillian Ewalt (she/her) is a librarian for visual resources at the University of Dayton
-  thumbnailUrl:
-  rockstar: false
-  ribbon:
-  social:
-
 - id: 37
   name: John
   surname: Burke


### PR DESCRIPTION
* Jillian Ewalt presented at 2020 but did not submit for 2021; I suspect that her data was somehow held over from last year by mistake. We should remove her from the speakers page.