### PR TITLE
fix lightning talks in the wrong sessions

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -261,16 +261,14 @@
 
 - id: 210
   subtype: session
-  speakers: [9, 31, 57, 39, 15, 62, 41]
+  speakers: [39, 15, 62, 41, 56, 40]
   title: 'Lightning Talks #1'
   description: >
     This session focuses on sustainability and connection in academic libraries 
     and consists of four short talks followed by a live Q&A: 
     <li>Essential but unusable: rehabilitating an aging digital collection (Neds-Fox & Hayes)</li>
     <li>Supporting Campus Innovation Efforts through Library Events (Longmeier)</li>
-    <li>Bridging the gap between sustainability and impact: The relationship 
-    between librarian involvement and the efficacy of information literacy 
-    instruction (Lenart, Murphy & Stoeckle)</li>
+    <li>Library Collaboration with College DEI Leadership Brings Mutual Benefits (Gaiser & Evans-Phillips)</li>
     <li>Exploring Mental Health First Aid Training as a Library Staff Crisis Management Tool
     (Wiener)</li>
   audience:
@@ -287,7 +285,7 @@
       'Library administration/supervision, diversity, consortia, emerging technologies, reference',
     ]
   keywords: geolocation, map-based interfaces, user interfaces, digital collections, community service, problem solving, archives, collection development, leaflet.js, python, PDF, geoJSON, informal learning, outreach, maker culture, Information literacy instruction, embedded librarianship, instructor-librarian collaborations, inquiry-based learning, text-analysis, Crisis Management Training, Professional Development, Mental Health, Staff Development, Staff Burnout
-  note-presenter-names: Bart Lenart,James Murphy,Marc Stoeckle , Joshua Neds-Fox,Clayton Hayes,Meris Longmeier,Judith Wiener,
+  note-presenter-names:  Joshua Neds-Fox,Clayton Hayes,Meris Longmeier,Judith Wiener,Madeleine Gaiser,Josie Evans-Phillips,
   live-stream-type: session
   live-stream-time: '2021-10-28 14:20:00'
   live-stream-link: https://zoom.us/j/99735980546?pwd=OWpPN01WMGZ5c2xpOHF4eEZhN1I2QT09
@@ -557,7 +555,7 @@
 
 - id: 309
   subtype: session
-  speakers: [30, 64, 25, 16, 27, 56, 40]
+  speakers: [9, 31, 57, 30, 64, 25, 16, 27]
   title: 'Lightning Talks #2'
   description: >
     This session focuses on collaboration and meaningful connection in 
@@ -568,8 +566,10 @@
     (Colosi)</li>
     <li>Conversations with Students: Using a Student Advisory Board for Dialogue 
     and Assessment (Wilhelm)</li>
+    <li>Bridging the gap between sustainability and impact: The relationship 
+    between librarian involvement and the efficacy of information literacy 
+    instruction (Lenart, Murphy & Stoeckle)</li>
     <li>Conspiracy Theories in the Classroom: COVID-19 Misinformation Edition (Schmillen)</li>
-    <li>Library Collaboration with College DEI Leadership Brings Mutual Benefits (Madeleine Gaiser & Evans-Phillips)</li>
   audience:
     [
       'IIG',
@@ -582,7 +582,7 @@
       'Library administration/supervision, diversity, consortia, emerging technologies, reference',
     ]
   keywords: Media Effects, Misinformation, Information Literacy, Student Organizations, Funding, Students, Assessment, Feedback, COVID-19, Discussion, Instruction, Anti-racism, DEI, Community
-  note-presenter-names: Jaclyn Spraetz,Nate Floyd, Giovanna Colosi, Cori Wilhelm,Hanna Schmillen,Madeleine Gaiser,Josie Evans-Phillips,
+  note-presenter-names: Jaclyn Spraetz,Nate Floyd, Giovanna Colosi, Cori Wilhelm,Hanna Schmillen, Bart Lenart,James Murphy,Marc Stoeckle
   video:
   live-stream-type: session
   live-stream-time: '2021-10-29 13:10:00'


### PR DESCRIPTION
Complies with this request from Cara:

> I was looking at the lighting talks and  Library Collaboration with College DEI Leadership Brings Mutual Benefits (Gaiser & Evans-Phillip) is one of my sessions but is not listed in  LT session #1 
> 
> LT session #1 has Bridging the gap between sustainability and impact: The relationship between librarian involvement and the efficacy of information literacy instruction (Lenart, Murphy & Stoeckle) which is one of Kristin Cole's Lts.
> 
> Can you please switch them. I'm getting ready to send our final communications before the conference and would like to head off any misunderstandings.